### PR TITLE
Install the latest TiDB version by default

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,4 @@
-TIDB_VERSION=v6.1.1
+# The latest version of TiDB is built by default.
+# Set `TIDV_VERSION` if you need to specify the TiDB version.
+# i.e.
+# TIDB_VERSION=v6.5.0

--- a/readme.md
+++ b/readme.md
@@ -7,11 +7,14 @@ Building a local development environment using the tidb-playground docker image 
 ## Usage
 
 ### Version
-vi .env
+`docker-tidb-playground` installs the latest TiDB version by default.
+If you need to specify the TiDB version, update the `.env` file as follows.
+
+- Edu .env
 ```
-TIDB_VERSION=v6.1.1
+TIDB_VERSION=v6.5.0
 ```
-[Other TiDB Versions](https://docs.pingcap.com/tidb/dev/release-notes) .
+Here are the available [TiDB Versions](https://docs.pingcap.com/tidb/dev/release-notes) .
 
 ### Build & Recreate
 


### PR DESCRIPTION
The current readme.md and .env specifies `TIDB_VERSION=v6.1.1` which is a little bit older.

Instead of updating the TIDB_VERSION every time, let tiup install the latest TiDB versions by default. If users want to specify the TiDB version they can specify it.

- When no `${TIDB_VERSION}` is set, `tiup install pd:${TIDB_VERSION}` install the latest version.

```shell
% unset TIDB_VERSION
% echo ${TIDB_VERSION}

% tiup install pd:${TIDB_VERSION} tidb:${TIDB_VERSION} tiflash:${TIDB_VERSION} tikv:${TIDB_VERSION} prometheus:${TIDB_VERSION}
download https://tiup-mirrors.pingcap.com/pd-v6.6.0-darwin-amd64.tar.gz 48.85 MiB / 48.85 MiB 100.00% 10.09 MiB/s
download https://tiup-mirrors.pingcap.com/tidb-v6.6.0-darwin-amd64.tar.gz 63.49 MiB / 63.49 MiB 100.00% 5.21 MiB/s
download https://tiup-mirrors.pingcap.com/tiflash-v6.6.0-darwin-amd64.tar.gz 67.15 MiB / 67.15 MiB 100.00% 9.85 MiB/s
download https://tiup-mirrors.pingcap.com/tikv-v6.6.0-darwin-amd64.tar.gz 30.31 MiB / 30.31 MiB 100.00% 10.24 MiB/s
download https://tiup-mirrors.pingcap.com/prometheus-v6.6.0-darwin-amd64.tar.gz 95.42 MiB / 95.42 MiB 100.00% 9.73 MiB/s
%
```

- When no `${TIDB_VERSION}` is set, `tiup playground` runs the latest TiDB version.

```shell
% tiup playground ${TIDB_VERSION} --host 0.0.0.0 --tag=devenv

tiup is checking updates for component playground ...
A new version of playground is available:
   The latest version:         v1.11.3
   Local installed version:
   Update current component:   tiup update playground
   Update all components:      tiup update --all

The component `playground` version  is not installed; downloading from repository.
download https://tiup-mirrors.pingcap.com/playground-v1.11.3-darwin-amd64.tar.gz 7.77 MiB / 7.77 MiB 100.00% 12.98 MiB/s
Starting component `playground`: /Users/yahonda/.tiup/components/playground/v1.11.3/tiup-playground --host 0.0.0.0 --tag=devenv
Using the version v6.6.0 for version constraint "".

If you'd like to use a TiDB version other than v6.6.0, cancel and retry with the following arguments:
    Specify version manually:   tiup playground <version>
    Specify version range:      tiup playground ^5
    The nightly version:        tiup playground nightly

Playground Bootstrapping...
Start pd instance:v6.6.0
Start tikv instance:v6.6.0
Start tidb instance:v6.6.0
Waiting for tidb instances ready
192.168.0.134:56386 ... Done
download https://tiup-mirrors.pingcap.com/grafana-v6.6.0-darwin-amd64.tar.gz 47.22 MiB / 47.22 MiB 100.00% 10.15 MiB/s
Start tiflash instance:v6.6.0
Waiting for tiflash instances ready
192.168.0.134:3930 ... Done
CLUSTER START SUCCESSFULLY, Enjoy it ^-^
To connect TiDB: mysql --comments --host 192.168.0.134 --port 56386 -u root -p (no password)
To view the dashboard: http://192.168.0.134:56385/dashboard
PD client endpoints: [192.168.0.134:56385]
To view the Prometheus: http://192.168.0.134:9090
To view the Grafana: http://192.168.0.134:56472
```